### PR TITLE
Fixed the issue on Github where the codeoutput would show <row>

### DIFF
--- a/src/components/CodeOutput.vue
+++ b/src/components/CodeOutput.vue
@@ -1,9 +1,9 @@
 <template>
   <pre>
 &lt;template&gt;
-<template v-for="row in rows">   &lt;row&gt;
+<template v-for="row in rows">   &lt;b-row&gt;
 <template v-for="item in row">{{ output_element(item) }}</template>
-   &lt;/row&gt;</template>
+   &lt;/b-row&gt;</template>
 &lt;/template&gt;
 
 &lt;script&gt;


### PR DESCRIPTION
and </row> instead of <b-row> and </b-row>